### PR TITLE
Allow mongo to be accessed over the network

### DIFF
--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -1,2 +1,6 @@
 ---
 # handlers file for ansible-role-mongodb
+- name: restart mongodb
+  service:
+    name: mongod
+    state: restarted

--- a/tasks/CentOS.yml
+++ b/tasks/CentOS.yml
@@ -44,3 +44,12 @@
 
     tags:
       - mongodb
+
+  - name: "Configure mongo to be accesible over the network"
+    become: yes
+    lineinfile:
+      dest: /etc/mongod.conf
+      line: "bind_ip=127.0.0.1"
+      state: absent
+    tags:
+      - mongodb

--- a/tasks/CentOS.yml
+++ b/tasks/CentOS.yml
@@ -51,5 +51,6 @@
       dest: /etc/mongod.conf
       line: "bind_ip=127.0.0.1"
       state: absent
+    notify: restart mongodb
     tags:
       - mongodb


### PR DESCRIPTION
This would also need some sort of firewall with it, but not in this role.
Besides that, this maybe should be an option (which is disabled by default) so people don't expose by default...